### PR TITLE
fix: disconnect the EventEmitter

### DIFF
--- a/src/kafka/consumer.js
+++ b/src/kafka/consumer.js
@@ -335,7 +335,7 @@ class Consumer extends EventEmitter {
       })
 
       this._consumer.on('disconnected', (metrics) => {
-        connectedClients.delete(this._consumer)
+        connectedClients.delete(this)
         Logger.isDebugEnabled && logger.debug(`Consumer::onDisconnected - ${JSON.stringify(metrics)}`)
         super.emit('disconnected', metrics)
       })
@@ -360,7 +360,7 @@ class Consumer extends EventEmitter {
           Logger.isSillyEnabled && logger.silly('Consumer::connect() - end')
           return reject(error)
         }
-        connectedClients.add(this._consumer)
+        connectedClients.add(this)
         Logger.isSillyEnabled && logger.silly('Consumer::connect() - metadata:')
         Logger.isSillyEnabled && logger.silly(metadata)
       })

--- a/src/kafka/producer.js
+++ b/src/kafka/producer.js
@@ -293,7 +293,7 @@ class Producer extends EventEmitter {
       })
 
       this._producer.on('disconnected', (metrics) => {
-        connectedClients.delete(this._producer)
+        connectedClients.delete(this)
         Logger.isDebugEnabled && logger.debug(`Producer::onDisconnected - ${JSON.stringify(metrics)}`)
         super.emit('disconnected', metrics)
       })
@@ -320,7 +320,7 @@ class Producer extends EventEmitter {
           Logger.isSillyEnabled && logger.silly('Producer::connect() - end')
           return reject(error)
         }
-        connectedClients.add(this._producer)
+        connectedClients.add(this)
         Logger.isSillyEnabled && logger.silly('Producer::connect() - metadata:')
         Logger.isSillyEnabled && logger.silly(metadata)
         resolve(true)


### PR DESCRIPTION
Found a better disconnect method within the class, so better use it to call the downstream one.