### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/test/perf/docker-compose.yml
+++ b/test/perf/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     container_name: kafka-provisioning
     networks:
       - kafka-net
-    image: docker.io/bitnami/kafka:3.4.0
+    image: docker.io/soldevelo/kafka:3.4.1
     env_file:
       - docker.env
     depends_on:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/kafka:3.4.0` → [`soldevelo/kafka:3.4.1`](https://hub.docker.com/r/soldevelo/kafka)